### PR TITLE
Fragments

### DIFF
--- a/lib/jerakia/datasource/file.rb
+++ b/lib/jerakia/datasource/file.rb
@@ -20,6 +20,7 @@ class Jerakia::Datasource
     end
 
     def import_file(filename)
+      Jerakia.log.debug("import_file() Importing #{filename}")
       if ::File.exists?(filename)
         ::File.read(filename)
       else
@@ -41,6 +42,12 @@ class Jerakia::Datasource
       end
     end
 
+    def list_fragments(prefix,extension)
+      if ::File.directory?("#{prefix}.d")
+        Dir["#{prefix}.d/*.#{extension}"]
+      end
+    end
+
     def read_from_file(fname)
       fpath = []
       fpath << options[:docroot] unless fname[0] == '/'
@@ -50,22 +57,17 @@ class Jerakia::Datasource
       diskname_prefix = "#{::File.join(fpath.flatten).gsub(/\/$/, '')}"
       diskname = "#{diskname_prefix}.#{extension}"
       
+      files = [ diskname ]
+      files << list_fragments(diskname_prefix, extension)
+      
+      raw_data=""
 
-      Jerakia.log.debug("read_from_file()  #{diskname}")
+      files.flatten.compact.each do |f|
+        Jerakia.log.debug("read_from_file()  #{f}")
+        raw_data << get_file_with_cache(f)
+      end
 
-     
-#      if options[:enable_caching]
-#        if cache.valid?(diskname) 
-#          Jerakia.log.debug("Returning cached data")
-#          cache.get(diskname)
-#        else
-#          Jerakia.log.debug("Adding contents of #{diskname} to cache")
-#          cache.add(diskname,@file_format.import_file(diskname))
-#        end
-#      else
-#        @file_format.import_file(diskname)
-#      end
-       @file_format.convert(get_file_with_cache(diskname))
+      file_format.convert(raw_data)
     end
 
 

--- a/lib/jerakia/datasource/file/yaml.rb
+++ b/lib/jerakia/datasource/file/yaml.rb
@@ -5,13 +5,16 @@ class Jerakia::Datasource
       EXTENSION='yaml'
 
       class << self
-      require 'yaml'
-      def import_file(fname)
-        Jerakia.log.debug("scanning file #{fname}")
-        return {} unless ::File.exists?(fname)
-        data=::File.read(fname)
-        YAML.load(data)
-      end
+        require 'yaml'
+        def import_file(fname)
+          Jerakia.log.debug("scanning file #{fname}")
+          return {} unless ::File.exists?(fname)
+          data=::File.read(fname)
+          YAML.load(data)
+        end
+        def convert(data)
+          YAML.load(data)
+        end
       end
     end
   end

--- a/lib/jerakia/datasource/file/yaml.rb
+++ b/lib/jerakia/datasource/file/yaml.rb
@@ -6,13 +6,8 @@ class Jerakia::Datasource
 
       class << self
         require 'yaml'
-        def import_file(fname)
-          Jerakia.log.debug("scanning file #{fname}")
-          return {} unless ::File.exists?(fname)
-          data=::File.read(fname)
-          YAML.load(data)
-        end
         def convert(data)
+          return {} if data.empty?
           YAML.load(data)
         end
       end

--- a/spec/features/fragments_spec.rb
+++ b/spec/features/fragments_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Jerakia do
+  before :each do
+    @jerakia = Jerakia.new(:config => "#{JERAKIA_ROOT}/test/fixtures/etc/jerakia/jerakia.yaml")
+    @request = Jerakia::Request.new
+  end
+
+  describe "Fragments" do
+
+    context "without fragements" do
+      before do
+        @answer=@jerakia.lookup(Jerakia::Request.new(
+          :metadata    => { :env => "dev", :hostname => "example" },
+          :key         => 'teststring',
+          :namespace   => [ 'test' ],
+        ) )
+      end
+
+      it "should return a response" do
+        expect(@answer).to be_a(Jerakia::Answer)
+      end
+
+      it "should have a string as a payload" do
+        expect(@answer.payload).to be_a(String)
+      end
+      
+      it "should contain the string valid_string" do
+        expect(@answer.payload).to eq("valid_string")
+      end
+    end
+
+    context "when a yaml file and a .d exist" do
+      before do
+        @answer=@jerakia.lookup(Jerakia::Request.new(
+          :key         => 'main',
+          :namespace   => [ 'fragments' ],
+        ) )
+      end
+
+      it "should contain the data from the parent" do
+        expect(@answer.payload).to eq("mummy bear")
+      end
+
+    end
+    context "when a value spans over a .d" do
+      before do
+        @answer=@jerakia.lookup(Jerakia::Request.new(
+          :key         => 'frag_array',
+          :namespace   => [ 'fragments' ],
+        ) )
+      end
+
+      it "should return an array" do
+        expect(@answer.payload).to be_a(Array)
+      end
+      
+      it "should have all the values from all the files" do
+        expect(@answer.payload).to eq(['first','second','third','fourth','fifth','sixth'])
+      end
+
+    end
+  end
+end
+

--- a/spec/unit/jerakia_spec.rb
+++ b/spec/unit/jerakia_spec.rb
@@ -19,11 +19,6 @@ describe Jerakia do
     context "a string" do
       before do
         @answer=@jerakia.lookup(Jerakia::Request.new(
-          :metadata => { :env => "dev", :hostname => "example" }
-        ))
-      end
-      before do
-        @answer=@jerakia.lookup(Jerakia::Request.new(
           :metadata    => { :env => "dev", :hostname => "example" },
           :key         => 'teststring',
           :namespace   => [ 'test' ],

--- a/test/fixtures/var/lib/jerakia/common/fragments.d/00_header.yaml
+++ b/test/fixtures/var/lib/jerakia/common/fragments.d/00_header.yaml
@@ -1,0 +1,3 @@
+frag_array:
+  - first
+

--- a/test/fixtures/var/lib/jerakia/common/fragments.d/01_other.yaml
+++ b/test/fixtures/var/lib/jerakia/common/fragments.d/01_other.yaml
@@ -1,0 +1,2 @@
+  - second
+  - third

--- a/test/fixtures/var/lib/jerakia/common/fragments.d/02_other.yaml
+++ b/test/fixtures/var/lib/jerakia/common/fragments.d/02_other.yaml
@@ -1,0 +1,3 @@
+  - fourth
+  - fifth
+  - sixth

--- a/test/fixtures/var/lib/jerakia/common/fragments.yaml
+++ b/test/fixtures/var/lib/jerakia/common/fragments.yaml
@@ -1,0 +1,3 @@
+---
+main: mummy bear
+


### PR DESCRIPTION

This enables the fragments feature for the file datasource.  

Jerakia will now search for foo.yaml as usual, but if it encounters a foo.d directory it will traverse into this directory and concatenate all files within it (alphabetically) into one document *before* handing it to the format handler (eg: yaml) - this makes large YAML files easier to break up and manage.

See test/fixtures/var/lib/jerakia/common/fragments.d for an example

