### PR TITLE
Allowing Jerakia::Config to take a hash

### DIFF
--- a/lib/jerakia.rb
+++ b/lib/jerakia.rb
@@ -10,12 +10,9 @@ class Jerakia
   require 'jerakia/launcher'
   require 'jerakia/cache'
 
-
-
-
   def initialize(options={})
     configfile = options[:config] || '/etc/jerakia/jerakia.yaml'
-    @@config = Jerakia::Config.new(configfile)
+    @@config = Jerakia::Config.load_from_file(configfile)
 
     if @@config[:plugindir]
       $LOAD_PATH << @@config[:plugindir] unless $LOAD_PATH.include?(@@config[:plugindir])
@@ -25,18 +22,15 @@ class Jerakia
     loglevel = options[:loglevel] || @@config["loglevel"] || "info"
     @@log = Jerakia::Log.new(loglevel.to_sym)
     @@log.debug("Jerakia initialized")
-
   end
 
   def lookup(request)
-    res=Jerakia::Launcher.new(request)
-    return res.answer
+    Jerakia::Launcher.new(request).answer
   end
 
   def config
     @@config
   end
-
 
   def self.fatal(msg,e)
     stacktrace=e.backtrace.join("\n")
@@ -44,7 +38,7 @@ class Jerakia
     Jerakia.log.fatal "Full stacktrace output:\n#{$!}\n\n#{stacktrace}"
     puts "Fatal error, check log output for details"
     throw Exception
-  end 
+  end
 
   def self.filecache(name)
     @@filecache[name] ||= File.read(name)
@@ -59,20 +53,15 @@ class Jerakia
     @@config
   end
 
-
   def log
     @@log
   end
-  
 
   def self.log
     @@log
   end
 
   def self.crit(msg)
-    
-    puts msg
-    throw Exception
+    fail msg
   end
 end
-

--- a/lib/jerakia/config.rb
+++ b/lib/jerakia/config.rb
@@ -1,25 +1,21 @@
-class Jerakia::Config
+require 'yaml'
 
-  require 'yaml'
+class Jerakia::Config
   attr_reader :policydir
   attr_reader :server_url
 
-  def initialize(config='/etc/jerakia/jerakia.yaml')
-    unless File.exists?(config)
-      Jerakia.crit("Config file #{config} not found")
-    end
-    rawdata=File.read(config)
-    ymldata=YAML.load(rawdata)
-    @policydir=ymldata['policydir']
-    @server_url=ymldata['server_url']
-    @configdata=ymldata
+  def self.load_from_file(file = '/etc/jerakia/jerakia.yaml')
+    Jerakia.crit("Config file #{file} not found") unless File.exists?(file)
+    new YAML.load_file(file)
+  end
+
+  def initialize(config)
+    @policydir = config['policydir']
+    @server_url = config['server_url']
+    @configdata = config
   end
 
   def [](key)
     @configdata[key.to_s]
   end
-
-
 end
-
-


### PR DESCRIPTION
Instead of taking a configuration file as a parameter to the `#initialize`
method on `Jerakia::Config`, let's take a hash of configuration options.
This lets us configure Jerakia in different ways (from a configuration
file being just one of them). This means that I can change Jerakia's
configuration at runtime (I'm specifically thinking during testing). I'm
also adding the `load_from_file` method so we can still load from a
configuration file. This commit also cleans up a few things in the
Jerakia class.