### PR TITLE
Improving CLI

### DIFF
--- a/bin/jerakia
+++ b/bin/jerakia
@@ -1,71 +1,8 @@
 #!/usr/bin/env ruby
 
-require 'jerakia'
-require 'json'
-require 'optparse'
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-options = {
-  :policy       => "default",
-  :config       => "/etc/jerakia/jerakia.yaml",
-  :scope        => nil,
-  :key          => nil,
-  :merge        => "array",
-  :lookup_type  => "first",
-  :namespace    => nil,
-  :metadata     => {},
-}
+require 'jerakia/cli'
 
-OptionParser.new do |opts|
-
-  opts.on("--config CONFIG","-c","Config file") do |c|
-    options[:config] = c
-  end
-
-  opts.on("--key KEY", "-k", "Lookup key") do |k|
-    options[:key] = k
-  end
-
-  opts.on("--policy POLICY", "-p", "Policy") do |p|
-    options[:policy] = p.to_sym
-  end
-
-  opts.on("--namespace NAMESPACE", "-n", "Namespace") do |n|
-    options[:namespace] = n.split(/::/)
-  end
-
-  opts.on("--type TYPE", "-t", "Lookup type") do |t|
-    options[:lookup_type] = t.to_sym
-  end
-
-  opts.on("--scope SCOPE", "-s", "Scope handler") do |s|
-    options[:scope] = s.to_sym
-  end
-
-  opts.on("--merge MERGE", "-m", "Merge type") do |m|
-    options[:merge] = m.to_sym
-  end
-end.parse!
-
-unless ARGV.empty?
-  ARGV.each do |arg|
-    meta=arg.split(':')
-    options[:metadata][meta[0]] = meta[1]
-  end
-end
-
-
-
-jac = Jerakia.new({:config => options[:config]})
-req = Jerakia::Request.new(
-  :key => options[:key],
-  :namespace => options[:namespace],
-  :policy => options[:policy].to_sym,
-  :lookup_type => options[:lookup_type].to_sym,
-  :merge       => options[:merge].to_sym,
-  :loglevel    => 'debug',
-  :metadata => options[:metadata]
-) 
-
-
-answer = jac.lookup(req)
-puts answer.payload.to_json
+Jerakia::CLI.start(ARGV)

--- a/jerakia.gemspec
+++ b/jerakia.gemspec
@@ -12,5 +12,6 @@ Gem::Specification.new do |s|
   s.executables << 'jerakia'
   s.homepage    = 'http://github.com/crayfishx/jerakia'
   s.license     = 'Apache 2.0'
+  s.add_dependency 'thor', '~> 0.19'
   s.add_dependency('lookup_http', '>=1.0.0')
 end

--- a/lib/jerakia.rb
+++ b/lib/jerakia.rb
@@ -10,9 +10,6 @@ class Jerakia
   require 'jerakia/launcher'
   require 'jerakia/cache'
 
-
-
-
   def initialize(options={})
     configfile = options[:config] || '/etc/jerakia/jerakia.yaml'
     @@config = Jerakia::Config.new(configfile)
@@ -25,7 +22,6 @@ class Jerakia
     loglevel = options[:loglevel] || @@config["loglevel"] || "info"
     @@log = Jerakia::Log.new(loglevel.to_sym)
     @@log.debug("Jerakia initialized")
-
   end
 
   def lookup(request)
@@ -44,7 +40,7 @@ class Jerakia
     Jerakia.log.fatal "Full stacktrace output:\n#{$!}\n\n#{stacktrace}"
     puts "Fatal error, check log output for details"
     throw Exception
-  end 
+  end
 
   def self.filecache(name)
     @@filecache[name] ||= File.read(name)
@@ -63,16 +59,14 @@ class Jerakia
   def log
     @@log
   end
-  
+
 
   def self.log
     @@log
   end
 
   def self.crit(msg)
-    
     puts msg
     throw Exception
   end
 end
-

--- a/lib/jerakia/cli.rb
+++ b/lib/jerakia/cli.rb
@@ -1,0 +1,60 @@
+require 'thor'
+require 'jerakia'
+require 'json'
+
+class Jerakia
+  class CLI < Thor
+    desc 'lookup [KEY]', 'Lookup [KEY] with Jerakia'
+    option :config,
+           aliases: :c,
+           type: :string,
+           default: '/etc/jerakia/jerakia.yaml',
+           desc: 'Configuration file'
+    option :policy,
+           aliases: :p,
+           type: :string,
+           default: 'default',
+           desc: 'Lookup policy'
+    option :namespace,
+           aliases: :n,
+           type: :string,
+           desc: 'Lookup namespace'
+    option :type,
+           aliases: :t,
+           type: :string,
+           default: 'first',
+           desc: 'Lookup type'
+    option :scope,
+           aliases: :s,
+           type: :string,
+           desc: 'Scope handler'
+    option :merge_type,
+           aliases: :m,
+           type: :string,
+           default: 'array',
+           desc: 'Merge type'
+    option :log_level,
+           aliases: :l,
+           type: :string,
+           desc: 'Log level'
+    option :metadata,
+           aliases: :d,
+           type: :hash,
+           desc: 'Key/value pairs to be used as metadata for the lookup'
+    def lookup(key)
+      jac = Jerakia.new({:config => options[:config]})
+      req = Jerakia::Request.new(
+        :key         => key,
+        :namespace   => options[:namespace].split(/::/),
+        :policy      => options[:policy].to_sym,
+        :lookup_type => options[:type].to_sym,
+        :merge       => options[:merge_type].to_sym,
+        :loglevel    => options[:log_level],
+        :metadata    => options[:metadata]
+      )
+
+      answer = jac.lookup(req)
+      puts answer.payload.to_json
+    end
+  end
+end


### PR DESCRIPTION
This commit moves away from OptionParser to Thor. I've used Thor for a
number of projects and it's my goto CLI library. This changes the CLI
behavior. Now there's a `lookup` subcommand. I made the metadata a flag
that can be passed explicitly instead of just chomping the remainder of
ARGV.