### PR TITLE
Bug/nested vars

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ task :hiera_test do
   sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test::binding'
     )
+  ENV['FACTER_env']=nil
 end
 
 task :hiera_compat_test do
@@ -31,6 +32,7 @@ task :hiera_compat_test do
   sh('puppet','apply','--debug','--data_binding_terminus',"jerakia",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera::subclass'
     )
+  ENV['FACTER_jerakia_policy'] = nil
 end
 
 
@@ -39,6 +41,7 @@ task :puppet_test do
   sh('puppet','apply','--debug','--data_binding_terminus',"jerakia",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test::binding'
     )
+  ENV['FACTER_env']=nil
 end
 
 task :policy_override_test do

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rspec/core/rake_task'
 
 @top_dir=Dir.pwd
 ENV['RUBYLIB'] = "#{@top_dir}/lib"
+ENV['JERAKIA_CONFIG'] = "#{@top_dir}/test/fixtures/etc/jerakia/jerakia.yaml"
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -17,7 +18,6 @@ task :hiera_test do
 end
 
 task :hiera_compat_test do
-  ENV['FACTER_env'] = 'dev'
   ENV['FACTER_jerakia_policy'] = 'hiera'
   sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera'
@@ -25,12 +25,17 @@ task :hiera_compat_test do
   sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera::subclass'
     )
+  sh('puppet','apply','--debug','--data_binding_terminus',"jerakia",
+     '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera'
+    )
+  sh('puppet','apply','--debug','--data_binding_terminus',"jerakia",
+     '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera::subclass'
+    )
 end
 
 
 task :puppet_test do
   ENV['FACTER_env'] = 'dev'
-  ENV['JERAKIA_CONFIG'] = "#{@top_dir}/test/fixtures/etc/jerakia/jerakia.yaml"
   sh('puppet','apply','--debug','--data_binding_terminus',"jerakia",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test::binding'
     )
@@ -41,7 +46,6 @@ task :policy_override_test do
   sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test::dummy'
     )
-  ENV['JERAKIA_CONFIG'] = "#{@top_dir}/test/fixtures/etc/jerakia/jerakia.yaml"
   sh('puppet','apply','--debug','--data_binding_terminus',"jerakia",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test::dummy'
     )

--- a/Rakefile
+++ b/Rakefile
@@ -52,4 +52,5 @@ task :policy_override_test do
 end
 
 
-task :default => [:hiera_test, :puppet_test, :spec]
+task :integration_tests => [:hiera_test, :hiera_compat_test, :puppet_test, :policy_override_test]
+task :default => [:integration_tests, :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,22 @@ task :hiera_test do
   sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
      '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test'
     )
+  sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
+     '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include test::binding'
+    )
 end
+
+task :hiera_compat_test do
+  ENV['FACTER_env'] = 'dev'
+  ENV['FACTER_jerakia_policy'] = 'hiera'
+  sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
+     '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera'
+    )
+  sh('puppet','apply','--debug','--hiera_config',"#{@top_dir}/test/int/puppet/hiera.yaml",
+     '--modulepath',"#{@top_dir}/test/int/puppet/modules",'-e','include hiera::subclass'
+    )
+end
+
 
 task :puppet_test do
   ENV['FACTER_env'] = 'dev'

--- a/lib/hiera/backend/jerakia_backend.rb
+++ b/lib/hiera/backend/jerakia_backend.rb
@@ -27,8 +27,8 @@ class Hiera
 
         if key.include?('::')
            lookup_key = key.split('::')
-           namespace << lookup_key.shift
-           key = lookup_key.join('::')
+           key = lookup_key.pop
+           namespace = lookup_key
         end
 
         Jerakia.log.debug("[hiera] backend invoked for key #{key} using namespace #{namespace}")

--- a/lib/jerakia.rb
+++ b/lib/jerakia.rb
@@ -63,7 +63,6 @@ class Jerakia
   end
 
   def self.crit(msg)
-    Jerakia.log.error msg
     fail msg
   end
 end

--- a/lib/jerakia/cli.rb
+++ b/lib/jerakia/cli.rb
@@ -17,6 +17,7 @@ class Jerakia
     option :namespace,
            aliases: :n,
            type: :string,
+           default: '',
            desc: 'Lookup namespace'
     option :type,
            aliases: :t,

--- a/lib/jerakia/cli.rb
+++ b/lib/jerakia/cli.rb
@@ -8,7 +8,6 @@ class Jerakia
     option :config,
            aliases: :c,
            type: :string,
-           default: '/etc/jerakia/jerakia.yaml',
            desc: 'Configuration file'
     option :policy,
            aliases: :p,

--- a/test/fixtures/etc/jerakia/policy.d/hiera.rb
+++ b/test/fixtures/etc/jerakia/policy.d/hiera.rb
@@ -1,0 +1,14 @@
+policy :hiera do
+
+  lookup :default, :use => :hiera do
+    datasource :file, {
+      :format => :yaml,
+      :docroot => "test/fixtures/var/lib/hiera",
+      :searchpath => [
+        "common"
+      ],
+    }
+    plugin.hiera.rewrite_lookup
+  end
+end
+

--- a/test/fixtures/var/lib/hiera/common.yaml
+++ b/test/fixtures/var/lib/hiera/common.yaml
@@ -1,0 +1,7 @@
+---
+
+hiera::first_level: "hiera_first"
+
+hiera::subclass::second_level: "hiera_second"
+
+

--- a/test/int/puppet/modules/hiera/manifests/init.pp
+++ b/test/int/puppet/modules/hiera/manifests/init.pp
@@ -1,0 +1,13 @@
+class hiera (
+  $first_level="class"
+) {
+
+  if ( $first_level == "hiera_first" ) {
+    notify { "PASS: hiera_first == $first_level": }
+  }else{
+    fail("FAIL: $first_level != hiera_first")
+  }
+}
+
+
+

--- a/test/int/puppet/modules/hiera/manifests/subclass.pp
+++ b/test/int/puppet/modules/hiera/manifests/subclass.pp
@@ -1,0 +1,12 @@
+class hiera::subclass (
+  $second_level = 'class'
+) {
+
+  if ( $second_level == "hiera_second" ) {
+    notify { "PASS: $second_level == hiera_second": }
+  } else {
+    fail("FAIL: $secondlevel != hiera_second")
+  }
+}
+
+


### PR DESCRIPTION
There was a bug with looking up nested variables where the namespace transcends more than one level from hiera (eg: foo::bar::tango).  This PR fixes it.  also added test coverage for hiera_compat in Rakefile