### PR TITLE
Bugfix: better handling of options validation for datasource.

### DIFF
--- a/lib/jerakia/datasource.rb
+++ b/lib/jerakia/datasource.rb
@@ -29,8 +29,8 @@ class Jerakia::Datasource
       Jerakia.crit "#{opt} must be configured in #{whoami}" if data[:mandatory]
     else 
       if data[:type]
-        unless Array(data[:type]).include?(@options[opt].class)
-          Jerakia.crit "#{opt} is a #{opt.class} but must be a #{data[:type].to_s} in #{whoami}"
+        if Array(data[:type]).select { |t| @options[opt].is_a?(t) }.empty?
+          Jerakia.crit "#{opt} is a #{@options[opt].class} but must be a #{data[:type].to_s} in #{whoami}"
         end
       end
     end


### PR DESCRIPTION

Scenario: when an option is specified as "Integer" the actual `.class` method in ruby returns `Fixnum` - the old method of handling data types meant these two were not equal, but they should be...

```ruby
[6] pry(#<Jerakia::Datasource>)> 1.is_a?(Integer)
=> true
[7] pry(#<Jerakia::Datasource>)> 1.is_a?(Fixnum)
=> true
```

 ```ruby
[3] pry(#<Jerakia::Datasource>)> @options[opt].class
=> Fixnum
```

Using is_a? in a select makes this compatible