### PR TITLE
Hiera plugin should not prepend "::" to keys when there is no namespace

### DIFF
--- a/lib/jerakia/lookup/plugin/hiera.rb
+++ b/lib/jerakia/lookup/plugin/hiera.rb
@@ -10,7 +10,9 @@ class Jerakia::Lookup::Plugin
   module Hiera
 
     def autorun
-      request.key.prepend("#{request.namespace.join('::')}::")
+      if request.namespace.length > 0
+        request.key.prepend("#{request.namespace.join('::')}::")
+      end
       request.namespace=[]
     end
 
@@ -27,5 +29,3 @@ class Jerakia::Lookup::Plugin
     end
   end
 end
-
-


### PR DESCRIPTION
For example, if searching for the key "classes" it would search for "::classes"; Which, in this instance, would break a hiera_include.