### PR TITLE
dont derive calling_module from namespace

### DIFF
--- a/lib/jerakia/lookup/plugin/hiera.rb
+++ b/lib/jerakia/lookup/plugin/hiera.rb
@@ -21,11 +21,7 @@ class Jerakia::Lookup::Plugin
     end
 
     def calling_module
-      if request.namespace.length > 0
-        request.namespace[0]
-      else
-        Jerakia.log.error("hiera_compat plugin tried to use calling_module but there is no namespace declared.  Ensure that calling_module is called before hiera_compat in the policy")
-      end
+      request.key.split('::')[0]
     end
   end
 end


### PR DESCRIPTION
Autorun will always delete the namespace and and merge the "calling_module" into the key - so we need to get the calling_module from the key, not the namespace.