### PR TITLE
Refactor of DSL parser

### DIFF
--- a/lib/jerakia.rb
+++ b/lib/jerakia.rb
@@ -26,7 +26,9 @@ class Jerakia
   end
 
   def lookup(request)
-    Jerakia::Launcher.new(request) { invoke_from_file }.answer
+    lookup_instance = Jerakia::Launcher.new(request)
+    lookup_instance.invoke_from_file
+    lookup_instance.answer
   end
 
   def config

--- a/lib/jerakia/dsl/lookup.rb
+++ b/lib/jerakia/dsl/lookup.rb
@@ -1,0 +1,66 @@
+class Jerakia
+  module Dsl
+    class Lookup
+
+      attr_reader :policy
+      attr_accessor :lookup
+
+      def initialize(name, policy, opts={})
+        @policy = policy
+        request = policy.clone_request
+        scope   = policy.scope
+        @lookup = Jerakia::Lookup.new(name, opts, request, scope)
+      end
+
+      def self.evaluate(name, policy, opts, &block)
+        lookup_block = new(name, policy, opts)
+        lookup_block.instance_eval &block
+        policy.submit_lookup(lookup_block.lookup)
+      end
+
+      def datasource(name, opts={})
+        datasource = Jerakia::Datasource.new(name, lookup, opts)
+        lookup.datasource=(datasource)
+      end
+
+      def request
+        policy.request
+      end
+
+      def scope
+        lookup.scope
+      end
+
+      # pass through exposed functions from the main lookup object
+      #
+      def confine(*args)
+        lookup.confine(*args)
+      end
+
+      def exclude(*args)
+        lookup.exclude(*args)
+      end
+
+      def invalidate
+        lookup.invalidate
+      end
+
+      def stop
+        lookup.stop
+      end
+
+      def continue
+        lookup.continue
+      end
+
+      def output_filter(*args)
+        lookup.output_filter(*args)
+      end
+
+      def plugin
+        lookup.plugin
+      end
+
+    end
+  end
+end

--- a/lib/jerakia/dsl/policy.rb
+++ b/lib/jerakia/dsl/policy.rb
@@ -1,0 +1,55 @@
+class Jerakia
+  module Dsl
+    class Policy
+
+      def self.evaluate_file(filename, request)
+        policy = new(request)
+        policy.evaluate_file(filename)
+        policy.instance
+      end
+
+      def self.evaluate(request, &block)
+        policy = new(request)
+        policy.instance_eval &block
+        policy.instance
+      end
+
+      attr_accessor :request
+      attr_reader   :instance
+
+      def initialize(req)
+        @request=req
+      end
+
+      def evaluate_file(filename)
+        policydata=Jerakia.filecache(filename)
+        instance_eval policydata
+      end
+
+      def policy(name, opts={}, &block)
+        @instance = Jerakia::Policy.new(name, opts, request)
+        Jerakia::Dsl::Policyblock.evaluate(instance,&block)
+      end
+      
+    end
+
+    class Policyblock
+
+      attr_accessor :policy
+
+      def initialize(policy)
+        @policy = policy
+      end
+
+      def self.evaluate(policy, &block)
+        policyblock = new(policy)
+        policyblock.instance_eval &block
+      end
+
+      def lookup(name, opts={}, &block)
+        Jerakia::Dsl::Lookup.evaluate(name, policy, opts, &block)
+      end
+    end
+  end
+
+end

--- a/lib/jerakia/lookup.rb
+++ b/lib/jerakia/lookup.rb
@@ -5,16 +5,17 @@ class Jerakia::Lookup
   require 'jerakia/lookup/pluginfactory'
 
   attr_accessor :request
-  attr_reader :datasource
-  attr_reader :valid
+  attr_accessor :datasource
+  attr_accessor :valid
+  attr_accessor :proceed
   attr_reader :lookuptype
   attr_reader :scope_object
   attr_reader :output_filters
   attr_reader :name
-  attr_reader :proceed
   attr_reader :pluginfactory
+  attr_reader :datasource
 
-  def initialize(name,opts,req,scope,&block)
+  def initialize(name,opts,req,scope)
     
     @name=name
     @request=req
@@ -29,18 +30,15 @@ class Jerakia::Lookup
         plugin_load(plugin)
       end
     end
-
-    instance_eval &block
-    
   end
  
   def plugin_load(plugin)
     Jerakia.log.debug("Loading plugin #{plugin}")
-    @pluginfactory.register(plugin, Jerakia::Lookup::Plugin.new(self))
+    pluginfactory.register(plugin, Jerakia::Lookup::Plugin.new(self))
   end
 
   def plugin
-    @pluginfactory
+    pluginfactory
   end
 
   def datasource(source, opts={})
@@ -52,7 +50,7 @@ class Jerakia::Lookup
   #
 
   def scope
-    @scope_object.value
+    scope_object.value
   end
 
 
@@ -61,7 +59,7 @@ class Jerakia::Lookup
   end
     
   def proceed?
-    @proceed
+    proceed
   end
 
   ## lookup function: stop
@@ -88,11 +86,11 @@ class Jerakia::Lookup
   # Setting invalidate will mean this lookup will be skipped in the policy
   #
   def invalidate
-    @valid=false
+    @valid = false
   end
 
   def valid?
-    return @valid
+    valid
   end
 
 
@@ -125,6 +123,8 @@ class Jerakia::Lookup
     return response
   end
 
+
+  private
 
 end
 

--- a/lib/jerakia/policy.rb
+++ b/lib/jerakia/policy.rb
@@ -1,76 +1,60 @@
 require 'jerakia/launcher'
+require 'jerakia/answer'
+require 'jerakia/schema'
 
 class Jerakia::Policy 
-  require 'jerakia/answer'
-  require 'jerakia/schema'
 
   attr_accessor :lookups
-  attr_reader   :routes
   attr_reader   :answer
   attr_reader   :scope
   attr_reader   :lookup_proceed
   attr_reader   :schema
+  attr_reader   :request
 
-  def initialize(name, opts={}, req, &block)
+  def initialize(name, opts={}, req)
 
     if req.use_schema and Jerakia.config[:enable_schema]
       schema_config = Jerakia.config[:schema] || {}
       @schema = Jerakia::Schema.new(req, schema_config)
     end
+
+
     @lookups=[]
     @routes={}
     @request=req
     @answer=Jerakia::Answer.new(req.lookup_type)
     @scope=Jerakia::Scope.new(req)
     @lookup_proceed = true    
-    begin
-      instance_eval &block
-    rescue => e
-      Jerakia.fatal "Error processing policy file", e
-    end
-  end
-
-
-  def request
-    @request
   end
 
   def clone_request
     Marshal.load(Marshal.dump(request))
   end
 
-
-  def lookup(name,opts={},&block)
-    # We specifically clone the request object to allow plugins to modify the
-    # request payload for the scope of this lookup only.
-    #
-    lookup = Jerakia::Lookup.new(name,opts,clone_request,scope,&block)
-    Jerakia.log.debug("Proceed to next lookup #{lookup.proceed?}")
-   
+  def submit_lookup(lookup)
     @lookups << lookup if lookup.valid? and @lookup_proceed
     @lookup_proceed = false if !lookup.proceed? and lookup.valid?
-
   end
 
   def fire!
-    @lookups.each do |l|
+    lookups.each do |l|
       responses = l.run
       responses.entries.each do |res|
         case request.lookup_type
         when :first
-          @answer.payload ||= res[:value]
-          @answer.datatype ||= res[:datatype]
+          answer.payload ||= res[:value]
+          answer.datatype ||= res[:datatype]
         when :cascade
-          @answer.payload << res[:value]
+          answer.payload << res[:value]
         end
       end
 
-      if request.lookup_type == :cascade && @answer.payload.is_a?(Array)
+      if request.lookup_type == :cascade && answer.payload.is_a?(Array)
         case request.merge
         when :array
-          @answer.flatten_payload!
+          answer.flatten_payload!
         when :hash,:deep_hash
-          @answer.merge_payload!(request.merge)
+          answer.merge_payload!(request.merge)
         end
       end
 

--- a/lib/jerakia/schema.rb
+++ b/lib/jerakia/schema.rb
@@ -9,7 +9,8 @@ class Jerakia::Schema
       :use_schema => false,
     )
 
-    schema_lookup = Jerakia::Launcher.new(schema_request) do
+    schema_lookup = Jerakia::Launcher.new(schema_request) 
+    schema_lookup.evaluate do
       policy :schema do
         lookup :schema do
           datasource *schema_datasource

--- a/test/fixtures/etc/jerakia/policy.d/default.rb
+++ b/test/fixtures/etc/jerakia/policy.d/default.rb
@@ -9,6 +9,8 @@ policy :default do
         "common",
     ],
     }
+
+    exclude request.key, "skippy"
   end
 end
 


### PR DESCRIPTION
This commit refactors a lot of stuff surrounding how we parse the
DSL.  It adds some separation between the core lookup and policy
libraries and the DSL.  It's part of a larger overhaul of how we
parse DSL