### PR TITLE
Changed marshal dump for clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ rvm:
   - 2.1
   - 2.2
 env:
+  - PUPPET_GEM_VERSION="~> 3.6.2"
   - PUPPET_GEM_VERSION="~> 3.7.0"
   - PUPPET_GEM_VERSION="~> 3.8.0"
+  - PUPPET_GEM_VERSION="~> 3.8.6"
   - PUPPET_GEM_VERSION="~> 4.1.0"
   - PUPPET_GEM_VERSION="~> 4.2.0"
   - PUPPET_GEM_VERSION="~> 4.3.0"
@@ -15,6 +17,10 @@ env:
 matrix:
   exclude:
     - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.6.2"
+    - rvm: 2.2
       env: PUPPET_GEM_VERSION="~> 3.7.0"
     - rvm: 2.2
       env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.2
+      env: PUPPET_GEM_VERSION="~> 3.8.6"

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ def run_puppet (type, modulename, facts={})
     args << '--data_binding_terminus'
     args << 'jerakia'
   end
-  args << [ '--modulepath', "#{@top_dir}/test/int/puppet/modules",'-e', "include #{modulename}" ]
+  args << [ '--modulepath', "#{@top_dir}/test/int/puppet/modules",'-e', " class barz() {} class { 'barz': } class { '#{modulename}': before => Class['barz'] }" ]
 
   facts.each { |fact,val| ENV["FACTER_#{fact}"] = val }
   sh(*args.flatten)

--- a/lib/jerakia/policy.rb
+++ b/lib/jerakia/policy.rb
@@ -36,7 +36,7 @@ class Jerakia::Policy
   end
 
   def clone_request
-    Marshal.load(Marshal.dump(request))
+    request.clone
   end
 
 


### PR DESCRIPTION
Marshal.dump was causing some strange errors under very specific
circumstances when jerakia was run through puppet.  This commit
replaces this with "request.clone" which passes the failing
tests

@hhenkel FYI