### PR TITLE
Bug: multiple lookups with hashes sometimes caused exception

### DIFF
--- a/lib/jerakia/policy.rb
+++ b/lib/jerakia/policy.rb
@@ -53,28 +53,32 @@ class Jerakia::Policy
   end
 
   def fire!
+    response_entries = []
+
     @lookups.each do |l|
       responses = l.run
-      responses.entries.each do |res|
-        case request.lookup_type
-        when :first
+      response_entries = responses.entries.map { |r| r }
+    end
+
+    response_entries.each do |res|
+      case request.lookup_type
+      when :first
           @answer.payload ||= res[:value]
           @answer.datatype ||= res[:datatype]
-        when :cascade
+      when :cascade
           @answer.payload << res[:value]
-        end
       end
-
-      if request.lookup_type == :cascade && @answer.payload.is_a?(Array)
-        case request.merge
-        when :array
-          @answer.flatten_payload!
-        when :hash,:deep_hash
-          @answer.merge_payload!(request.merge)
-        end
-      end
-
     end
+
+    if request.lookup_type == :cascade && @answer.payload.is_a?(Array)
+      case request.merge
+      when :array
+        @answer.flatten_payload!
+      when :hash,:deep_hash
+        @answer.merge_payload!(request.merge)
+      end
+    end
+
   end
 end
 

--- a/test/fixtures/etc/jerakia/policy.d/default.rb
+++ b/test/fixtures/etc/jerakia/policy.d/default.rb
@@ -1,4 +1,16 @@
 policy :default do
+
+
+  lookup :invalid do
+    datasource :file, {
+      :docroot    => "test/fixtures/var/lib/jerakia/data",
+      :format     => :yaml,
+      :searchpath => [
+        "invalid",
+    ],
+    }
+  end
+
   lookup :default do
     datasource :file, {
       :docroot    => "test/fixtures/var/lib/jerakia/data",

--- a/test/fixtures/var/lib/jerakia/schema/test.json
+++ b/test/fixtures/var/lib/jerakia/schema/test.json
@@ -8,5 +8,6 @@
     "cascade": true,
     "merge": "hash"
   }
+
 }
 


### PR DESCRIPTION
This bug can be simulated by having two lookups, where the first
lookup is valid but returns no data, so the second lookup is used.
In this scenario, an exception is raised because the first lookup
sets the answers payload to {} and the second lookup tries to
append to it.

`test/fixtures/etc/jerakia/policy.d/default.rb` has a policy file
that simulates it, if you look up a cascading hash using this policy
it will fail with an exception.

This commit changes the code flow and gathers all the responses from
all the lookups first, before parsing the answer object.  The policy code to trigger this is:

```ruby
policy :default do


  lookup :invalid do
    datasource :file, {
      :docroot    => "test/fixtures/var/lib/jerakia/data",
      :format     => :yaml,
      :searchpath => [
        "invalid",
    ],
    }
  end

  lookup :default do
    datasource :file, {
      :docroot    => "test/fixtures/var/lib/jerakia/data",
      :format     => :yaml,
      :searchpath => [
        "host/#{scope[:hostname]}",
        "env/#{scope[:env]}",
        "common",
    ],
    }
  end
end
```

When looking up a cascading hash where the first lookup will not return a result, but is valid  and there is no `stop` in the lookup...

```
$ bin/jerakia lookup cities -n test --metadata env:dev --no-schema --type cascade --merge_type hash
```

We get the following exception

```
/Users/craigdunn/git/jerakia/lib/jerakia/launcher.rb:22:in `instance_eval': undefined method `<<' for {}:Hash (NoMethodError)
```