### PR TITLE
Fixed: data source boolean options 

### DIFF
--- a/lib/jerakia/datasource.rb
+++ b/lib/jerakia/datasource.rb
@@ -26,7 +26,10 @@ class Jerakia::Datasource
   end
 
   def option(opt, data={})
-    @options[opt] ||= data[:default] || nil
+    if @options[opt].nil? and data.key?(:default)
+      @options[opt] = data[:default]
+    end
+    
     Jerakia.log.debug("[#{whoami}]: options[#{opt}] to #{options[opt]} [#{options[opt].class}]")
     if @options[opt].nil?
       raise Jerakia::PolicyError, "#{opt} option must be supplied for datasource #{@name} in lookup #{lookup.name}" if data[:mandatory]


### PR DESCRIPTION
If a data source has a boolean option defaulting to true,  setting false in the policy will not override the value... this fixes the issue by evaluating on `nil?` rather than true when deciding whether or not to use defaults.