### PR TITLE
Bugfixes for cloning.

### DIFF
--- a/lib/hiera/backend/jerakia_backend.rb
+++ b/lib/hiera/backend/jerakia_backend.rb
@@ -1,3 +1,6 @@
+require 'puppet'
+require 'puppet/resource'
+
 class Hiera
   module Backend
     class Jerakia_backend

--- a/lib/hiera/backend/jerakia_backend.rb
+++ b/lib/hiera/backend/jerakia_backend.rb
@@ -35,9 +35,9 @@ class Hiera
 
         metadata={}
         if scope.is_a?(Hash)
-          metadata=scope
+          metadata=scope.reject { |k, v| v.is_a?(Puppet::Resource) }
         else
-          metadata = scope.real.to_hash
+          metadata = scope.real.to_hash.reject { |k, v| v.is_a?(Puppet::Resource) }
         end
 
         request = Jerakia::Request.new(

--- a/lib/jerakia/cli.rb
+++ b/lib/jerakia/cli.rb
@@ -70,6 +70,11 @@ class Jerakia
 
 
     def lookup(key)
+      # Thor by default now returns a frozen options hash so we 
+      # need to dup this here to prevent problems later with
+      # modifying the request object
+      #
+      options_copy = options.dup
 
       case true
       when options[:verbose]
@@ -92,15 +97,15 @@ class Jerakia
           :trace    => options[:trace],
         })
         req = Jerakia::Request.new(
-          :key           => key,
-          :namespace     => options[:namespace].split(/::/),
-          :policy        => options[:policy].to_sym,
-          :lookup_type   => options[:type].to_sym,
-          :merge         => options[:merge_type].to_sym,
-          :metadata      => options[:metadata] || {},
-          :scope         => options[:scope].to_sym,
-          :scope_options => options[:scope_options],
-          :use_schema    => options[:schema],
+          :key           => key.dup,
+          :namespace     => options_copy[:namespace].split(/::/),
+          :policy        => options_copy[:policy].to_sym,
+          :lookup_type   => options_copy[:type].to_sym,
+          :merge         => options_copy[:merge_type].to_sym,
+          :metadata      => options_copy[:metadata] || {},
+          :scope         => options_copy[:scope].to_sym,
+          :scope_options => options_copy[:scope_options],
+          :use_schema    => options_copy[:schema],
         )
 
 

--- a/lib/jerakia/policy.rb
+++ b/lib/jerakia/policy.rb
@@ -27,8 +27,7 @@ class Jerakia::Policy
   end
 
   def clone_request
-    copy_request = request.clone
-    return copy_request
+    Marshal.load(Marshal.dump(request))
   end
 
   def submit_lookup(lookup)

--- a/lib/puppet/indirector/data_binding/jerakia.rb
+++ b/lib/puppet/indirector/data_binding/jerakia.rb
@@ -19,7 +19,7 @@ class Puppet::DataBinding::Jerakia < Puppet::Indirector::Code
     lookupdata=request.key.split(/::/)
     key=lookupdata.pop
     namespace=lookupdata
-    metadata =  request.options[:variables].to_hash
+    metadata =  request.options[:variables].to_hash.reject { |k, v| v.is_a?(Puppet::Resource) }
     policy=metadata["jerakia_policy"] || @default_policy
     jacreq = Jerakia::Request.new(
       :key => key,

--- a/test/fixtures/etc/jerakia/policy.d/hiera.rb
+++ b/test/fixtures/etc/jerakia/policy.d/hiera.rb
@@ -1,5 +1,10 @@
 policy :hiera do
 
+  lookup :skip, :use => :hiera do
+    datasource :dummy, { :return => 'foo'}
+    confine request.key, 'never' # never use this lookup
+  end
+
   lookup :default, :use => :hiera do
     datasource :file, {
       :format => :yaml,


### PR DESCRIPTION

The hiera metadata added Puppet::Resource objects for metaparameters like before, require...etc, these caused Marshal.dump to fail when cloning the request.  Removing Marshal.dump caused other issues (see #60 ) - this PR addresses the initial problem by filtering out `Puppet::Resource` objects from the metadata and reverting the clone back to `Marshal.dump/Marshal.load`

Also - thor now freezes options by default, this was causing problems cloning when using the command line

* Reject `Puppet::Resource` from metadata (hiera backend)
* Duplicate the options hash so options aren't frozen (CLI)
* Reverted the clone method back to Marshal.dump

