### PR TITLE
Add config method to lookup plugins.

### DIFF
--- a/lib/jerakia/lookup.rb
+++ b/lib/jerakia/lookup.rb
@@ -3,6 +3,7 @@ class Jerakia::Lookup
   require 'jerakia/scope'
   require 'jerakia/lookup/plugin'
   require 'jerakia/lookup/pluginfactory'
+  require 'jerakia/lookup/plugin_config'
 
   attr_accessor :request
   attr_accessor :datasource
@@ -41,9 +42,16 @@ class Jerakia::Lookup
     end
   end
 
+  # Retrieve plugin specific configuration from the global configuration file
+  # gets passed to the plugin instance upon initilization.
+  #
+  def plugin_config(plugin)
+    Jerakia::Lookup::PluginConfig.new(plugin)
+  end
+
   def plugin_load(plugin)
     Jerakia.log.debug("Loading plugin #{plugin}")
-    pluginfactory.register(plugin, Jerakia::Lookup::Plugin.new(self))
+    pluginfactory.register(plugin, Jerakia::Lookup::Plugin.new(self, plugin_config(plugin)))
   end
 
   def plugin

--- a/lib/jerakia/lookup/plugin.rb
+++ b/lib/jerakia/lookup/plugin.rb
@@ -1,13 +1,16 @@
 class Jerakia::Lookup::Plugin
   attr_reader :lookup
+  attr_reader :config
 
-  def initialize(lookup)
+  def initialize(lookup, config)
     @lookup = lookup
+    @config = config
   end
 
   def activate(name)
     instance_eval "extend Jerakia::Lookup::Plugin::#{name.to_s.capitalize}"
   end
+
 
   def scope
     lookup.scope

--- a/lib/jerakia/lookup/plugin_config.rb
+++ b/lib/jerakia/lookup/plugin_config.rb
@@ -1,0 +1,31 @@
+# Jerakia::Lookup::PluginConfig
+#
+# This class is a simple wrapper class to expose configuration options
+# from the global configuration file to lookup plugins.  It's exposed
+# to the lookup as the config method.  Eg: config[:foo]
+#
+class Jerakia
+  class Lookup
+    class PluginConfig
+
+      attr_reader :plugin_name
+      attr_reader :config
+
+      def initialize(plugin_name)
+        @plugin_name = plugin_name
+        @config = {}
+        if Jerakia.config[:plugins].is_a?(Hash)
+          @config = Jerakia.config[:plugins][plugin_name.to_s] || {}
+        end
+      end
+
+      def [](key)
+        config[key.to_s]
+      end
+
+    end
+  end
+end
+        
+
+

--- a/test/fixtures/etc/jerakia/jerakia.yaml
+++ b/test/fixtures/etc/jerakia/jerakia.yaml
@@ -8,4 +8,6 @@ plugindir: test/fixtures/etc/jerakia/lib
 schema:
   docroot: test/fixtures/var/lib/jerakia/schema
 
-
+plugins:
+  hiera:
+    foo: bar


### PR DESCRIPTION
This adds the capability to plugins to be configured directly from
jerakia.yaml.  Config can be placed in the 'plugins' hash under a key
representing the plugin name, Jerakia::Lookup::PluginConfig is a class
who's instances expose the underlying hash to the lookup plugin from
the config method.

Eg: the following configuration in jerakia.yaml

```yaml
plugins:
  myplugin:
    setting: value
```

is referenced in the lookup plugin myplugin as

```
config[:setting]  # => "value"
```

Currently the hash is also passed as a hash to the autorun method of
the pllugin - this will be deprecated in a future version.