### PR TITLE
added server scope, api endpoints and various bug fixes for 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swo
+*.swp
+test/fixtures/var/db/jerakia/*
+

--- a/lib/jerakia/scope/server.rb
+++ b/lib/jerakia/scope/server.rb
@@ -1,0 +1,66 @@
+require 'securerandom'
+require 'data_mapper'
+# The server scope handler can store and retrieve scope data server side
+#
+class Jerakia::Scope
+  module Server
+    class Database
+      DataMapper.setup(:scope, "sqlite://#{Jerakia.config[:databasedir]}/scope.db")
+      Jerakia.log.debug("Server scope handler connected to sqlite://#{Jerakia.config[:databasedir]}/scope.db")
+
+      class Resource
+        include DataMapper::Resource
+
+
+        def self.default_repository_name
+          :scope
+        end
+
+        property :id, Serial, :key => true
+        property :identifier, String, :index => true
+        property :realm, String, :index => true
+        property :uuid, String
+        property :scope, Object
+      end
+
+      DataMapper.finalize
+      DataMapper.auto_upgrade!
+    end
+
+    def create
+      realm = request.scope_options['realm']
+      identifier = request.scope_options['identifier']
+
+      raise Jerakia::Error, "Must supply realm and identifier for server scope handler" unless realm and identifier
+      resource = Jerakia::Scope::Server.find(realm, identifier)
+      raise Jerakia::Error, "No scope data found for realm:#{realm} identifier:#{identifier}" if resource.nil?
+      scope = resource.scope
+      raise Jerakia::Error, "Scope did not return a hash for realm:#{realm} identifier:#{identifier}" unless scope.is_a?(Hash)
+      @value = scope
+    end
+
+    class << self
+      def find(realm, identifier)
+        Database::Resource.first(:identifier => identifier, :realm => realm)
+      end
+
+
+      def store(realm, identifier, scope)
+        uuid = SecureRandom.uuid
+        entry = find(realm, identifier)
+        if entry.nil?
+          Database::Resource.create(:identifier => identifier, :realm => realm, :scope => scope, :uuid => uuid)
+        else
+          entry.update({:scope => scope, :uuid => uuid})
+          entry.save
+        end
+        uuid
+      end
+    end
+  end
+end
+
+
+
+
+

--- a/lib/jerakia/server/auth/token.rb
+++ b/lib/jerakia/server/auth/token.rb
@@ -8,12 +8,17 @@ class Jerakia
     class Auth
 
       Jerakia.log.debug("Authentication database sqlite://#{Jerakia.config[:vardir]}/tokens.db")
-      DataMapper.setup(:default, "sqlite://#{Jerakia.config[:vardir]}/tokens.db")
+
+      DataMapper.setup(:tokens, "sqlite://#{Jerakia.config[:databasedir]}/tokens.db")
 
       class Token
 
         include DataMapper::Resource
         include BCrypt
+
+        def self.default_repository_name
+          :tokens
+        end
 
         property :api_id, String, :key => true
         property :token, BCryptHash

--- a/lib/jerakia/server/rest.rb
+++ b/lib/jerakia/server/rest.rb
@@ -1,6 +1,8 @@
 require 'sinatra'
 require 'jerakia'
 require 'jerakia/server/auth'
+require 'json'
+require 'jerakia/scope/server'
 
 class Jerakia
   class Server
@@ -52,6 +54,39 @@ class Jerakia
           :status => 'ok',
           :payload => answer.payload
         }.to_json
+      end
+
+      get '/v1/scope/:realm/:identifier' do
+        resource = Jerakia::Scope::Server.find(params['realm'], params['identifier'])
+        if resource.nil?
+          halt(404, { :status => 'failed', :message => "No scope data found" }.to_json)
+        else
+          {
+            :status => 'ok',
+            :payload => resource.scope
+          }.to_json
+        end
+      end
+
+      put '/v1/scope/:realm/:identifer' do
+        scope = JSON.parse(request.body.read)
+        uuid = Jerakia::Scope::Server.put(params['realm'], params['identifier'], scope)
+        {
+          :status => 'ok',
+          :uuid => uuid
+        }.to_json
+      end
+
+      get '/v1/scope/:realm/:identifier/uuid' do
+        resource = Jerakia::Scope::Server.find(params['realm'], params['identifier'])
+        if resource.nil?
+          halt(404, { :status => 'failed', :message => "No scope data found" }.to_json)
+        else
+          {
+            :status => 'ok',
+            :uuid => resource.uuid
+          }.to_json
+        end
       end
     end
   end

--- a/lib/jerakia/server/token.rb
+++ b/lib/jerakia/server/token.rb
@@ -1,9 +1,0 @@
-require 'data_mapper'
-require 'dm-sqlite-adapter'
-require 'bcrypt'
-
-class Jerakia
-  class Auth
-    class 
-
-

--- a/test/fixtures/etc/jerakia/jerakia.yaml
+++ b/test/fixtures/etc/jerakia/jerakia.yaml
@@ -3,8 +3,10 @@ policydir: test/fixtures/etc/jerakia/policy.d
 logfile: /dev/null
 loglevel: debug
 plugindir: test/fixtures/etc/jerakia/lib
-vardir: /tmp
-piddir: test/fixtures/var/run
+
+# Location of internal Jerakia databases used for scope storage, token management..etc
+#databasedir: test/fixtures/var/db/jerakia
+databasedir: /tmp
 
 
 schema:


### PR DESCRIPTION

This PR adds a new scope handler called 'server'.... This allows Jerakia itself to store a local copy of the scope (facts, for Puppet integration).  This stems from a conversation on slack with Henrik regarding the new lookup functionality expected in Puppet 4.9, and will also enable us to deprecate the current ruby bindings for the hiera backend and data_binding_terminus in favour of REST API calls to Jerakia Server, thus de-coupling Puppet and Jerakia from being tied together at the ruby level.  Since using the puppetDB scope handler is impractical for Puppet runs because there is no guarantee that the facts in puppetDB will be the latest at the point that data lookups are done.  We don't want to have to send all the facts to Jerakia everytime we want to do a data lookup as that means using POST for everything and it's very expensive due to the amount of data.  So this new scope handler and API addition serves to address this

The general idea is that the the API exposes endpoints allowing a set of scope data to be sent to Jerakia with an identifier (certname) and a realm (puppet)... realm is just future proofing incase we start doing this with more than one tool simultanously we can separate out the scopes

So when using Jerakia Server, the interaction between Puppet and Jerakia would look something like

* Begin puppet run
* Puppet sends facts to `PUT /v1/scope/puppet/certname`
* Jerakia sends back a UUID to identify the revision of the scope, this gets cached
* For each lookup in this Puppet run, Puppet requests `GET /v1/lookup/key?namespace=module&scope=server&scope_opt_identifier=certname&scope_opt_realm=puppet`

For the next Puppet run, Puppet will know that it needs to refresh the facts and will send the `PUT` again, which causes Jerakia to replace the scope content.

This PR also contains some other general bug fixes for 1.2 features.