### PR TITLE
Add token_ttl option to server.

### DIFF
--- a/lib/jerakia/config.rb
+++ b/lib/jerakia/config.rb
@@ -24,7 +24,7 @@ class Jerakia::Config
       'loglevel'      => 'info',
       'vardir'        => '/var/lib/jerakia',
       'piddir'        => '/var/run',
-      'enable_schema' => true
+      'enable_schema' => true,
     }
   end
 

--- a/lib/jerakia/server.rb
+++ b/lib/jerakia/server.rb
@@ -4,19 +4,22 @@ require 'thin'
 class Jerakia
   class Server
 
-    @jerakia = nil
-    @config = {}
-
     def jerakia
       self.class.jerakia
     end
 
     class << self
 
+      @jerakia = nil
+      @config = {}
+
+      attr_reader :config
+
       def default_config
         {
         'bind' => '127.0.0.1',
         'port' => '9843',
+        'token_ttl' => 300,
         }
       end
 


### PR DESCRIPTION

The biggest bottleneck for API calls to Jerakia Server seems to be calls to the database to verify the token - by adding `token_ttl` (default 300 seconds) then the token is cached in memory and only refreshed once the cache expires.  This makes a massive difference to the response time of the API