### PR TITLE
Bug/policy confine

### DIFF
--- a/lib/jerakia/policy.rb
+++ b/lib/jerakia/policy.rb
@@ -32,7 +32,7 @@ class Jerakia
       response_entries = []
       lookups.each do |lookup|
         lookup_instance = lookup.call clone_request(request), scope
-        next unless lookup_instance.valid? && lookup_instance.proceed?
+        next unless lookup_instance.valid?
         register_datasource lookup_instance.datasource[:name]
         responses = Jerakia::Datasource.run(lookup_instance)
         lookup_instance.output_filters.each do |filter|
@@ -41,6 +41,7 @@ class Jerakia
         end
         lookup_answers = responses.entries.map { |r| r}
         response_entries << lookup_answers if lookup_answers
+        break unless lookup_instance.proceed?
       end
       answer.process_response(response_entries)
       return answer

--- a/spec/features/stop_spec.rb
+++ b/spec/features/stop_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Jerakia do
+  let(:subject) { Jerakia.new(:config =>  "#{JERAKIA_ROOT}/test/fixtures/etc/jerakia/jerakia.yaml") }
+  let(:request) { Jerakia::Request.new }
+  let(:answer) { subject.lookup(request) }
+
+  describe 'Confined lookup' do
+    context 'when looking up a confined lookup' do
+      let(:request) do
+        Jerakia::Request.new(
+          metadata: { testing: 'yes' },
+          key: 'foo',
+          namespace: ['test_conf'],
+          lookup_type: :cascade,
+          merge: :array,
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should return the answer' do
+        expect(answer.payload).to eq(['Success'])
+      end
+
+    end
+
+  end
+end

--- a/test/fixtures/etc/jerakia/policy.d/default.rb
+++ b/test/fixtures/etc/jerakia/policy.d/default.rb
@@ -18,6 +18,16 @@ policy :default do
 
   end
 
+  lookup :test_confine do
+    datasource :dummy, {
+      :return => "Success"
+    }
+
+    confine request.namespace[0], "test_conf"
+    confine scope[:testing], "yes"
+    stop
+  end
+
   lookup :default do
     datasource :file, {
       :docroot    => "test/fixtures/var/lib/jerakia/data",

--- a/test/fixtures/var/lib/jerakia/data/common/test_conf.yaml
+++ b/test/fixtures/var/lib/jerakia/data/common/test_conf.yaml
@@ -1,0 +1,2 @@
+---
+foo: Failure


### PR DESCRIPTION

A bug in 2.0 caused lookups using the `stop` method to never get run due to how `proceed?` was being evaluated.
