### PR TITLE
Add msgpack support to jerakia

### DIFF
--- a/test/fixtures/var/lib/jerakia/data/common/test.yaml
+++ b/test/fixtures/var/lib/jerakia/data/common/test.yaml
@@ -61,4 +61,7 @@ databases:
     boo:
       bear: baz
 
-
+msgpack:
+  values:
+    1: "Test 1"
+    '2': "Test 2"


### PR DESCRIPTION
This PR tries to solve the inconsistency mentioned in #95 and adds support for [msgpack](http://msgpack.org/) as an alternative to JSON for the jerakia api server. It does not try to alter the behavior of interpreting numerical keys with leading zeros as octal numbers.

For backwards compatibility I tried to keep the current behavior of using JSON as a default when no content type header is set. I also added the possibility to set the content type to `application/json` and made it the default in my jerakia-client implementation.

When a client sends a request with `application/x-msgpack` the server replies with the msgpack format. 

As other content types are currently not supported the server should inform the client about that - this is done via [HTTP Error 415](https://httpstatuses.com/415).

Example data:
```
---
msgpack:
  values:
    1: "Test 1"
    '2': "Test 2"
    03: "Test 3"
    '04': "Test 4"
    0567: "Test 5"
    '0567': "Test 6"
    0569: "Test 7"
    '0569': "Test 8"
```

YAML output:
```
bin/jerakia-client lookup -o yaml --namespace test  msgpack
---
values:
  1: Test 1
  '2': Test 2
  3: Test 3
  '04': Test 4
  375: Test 5
  '0567': Test 6
  0569: Test 8
```