### PR TITLE
improved error reporting and softer handline of no log file

### DIFF
--- a/bin/jerakia
+++ b/bin/jerakia
@@ -4,5 +4,9 @@ lib = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'jerakia/cli'
-
+begin
 Jerakia::CLI.start(ARGV)
+rescue Jerakia::Error => e
+  STDERR.puts "Error(#{e.class}): #{e.message}"
+  exit 1
+end

--- a/bin/jerakia
+++ b/bin/jerakia
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'jerakia/cli'
 begin
-Jerakia::CLI.start(ARGV)
+  Jerakia::CLI.start(ARGV)
 rescue Jerakia::Error => e
   STDERR.puts "Error(#{e.class}): #{e.message}"
   exit 1

--- a/lib/jerakia/cli.rb
+++ b/lib/jerakia/cli.rb
@@ -16,7 +16,6 @@ class Jerakia
     include Jerakia::CLI::Secret
     include Jerakia::CLI::Config
 
-
     desc 'version', 'Version information'
     def version
       puts Jerakia::VERSION

--- a/lib/jerakia/log.rb
+++ b/lib/jerakia/log.rb
@@ -3,8 +3,9 @@ class Jerakia::Log < Jerakia
   def initialize(level = :info, file = '/var/log/jerakia.log')
     begin
       @@logger = Logger.new(file)
-    rescue Errno::EACCES => e
-      raise Jerakia::Error, "Error opening log file, #{e.message}"
+    rescue Errno::EACCES, Errno::ENOENT => e
+      @@logger = Logger.new(STDOUT)
+      info("Failed to open logfile: #{e.message}, logs will be directed to STDOUT")
     end
 
     @@level = level

--- a/lib/jerakia/server/auth/token.rb
+++ b/lib/jerakia/server/auth/token.rb
@@ -26,8 +26,12 @@ class Jerakia
         property :last_seen, DateTime, :default => DateTime.now
       end
 
-      DataMapper.finalize
-      DataMapper.auto_upgrade!
+     begin
+        DataMapper.finalize
+        DataMapper.auto_upgrade!
+      rescue DataObjects::ConnectionError => e
+        raise Jerakia::Error, "Unable to open database file in #{Jerakia.config[:databasedir]}: #{e.message}"
+      end
     end
   end
 end


### PR DESCRIPTION

Particularly when installing from a Gem, Jerakia fails to start until a few bits of scaffolding are in place, mainly the `databasedir` and `logfile`.  In the case of logging Jerakia would throw an exception and bail out - this is frustrating and a bit unneccesary this PR changes the behaviour so logs are redirected to `STDOUT` and gives the following warning if the logfile cannot be opened;

`I, [2017-08-11T14:29:47.695526 #17466]  INFO -- : Failed to open logfile: Permission denied @ rb_sysopen - /var/log/jerakia/jerakia.log, logs will be directed to STDOUT`

But Jerakia will not throw an exception and will keep on running with logs going to `STDOUT`

In the case of the `databasedir` being unavailable or unwritable, this caused Jerakia to throw an exception that was confusing to understand - we now catch this exception with a decent error message.

Furthermore, all `Jerakia::Error` exceptions are now caught for all subcommands on the CLI and presented in a more readable way to the user, eg:

```
$ bin/jerakia token create craig
Error(Jerakia::Error): Unable to open database file in /var/db/jerakia: unable to open database file
```