### PR TITLE
Added found attribute to answers to differentiate null from not found

### DIFF
--- a/lib/jerakia/answer.rb
+++ b/lib/jerakia/answer.rb
@@ -10,6 +10,7 @@ class Jerakia
     def initialize(lookup_type = :first, merge_strategy = :array)
       @lookup_type = lookup_type
       @merge_strategy = merge_strategy
+      @found = false
       case lookup_type
       when :first
         @payload = nil
@@ -20,7 +21,12 @@ class Jerakia
     end
 
     def process_response(response_entries)
-      response_entries.flatten.each do |res|
+      responses = response_entries.flatten.compact
+
+      return nil if responses.empty?
+      @found = true
+
+      responses.each do |res|
         case lookup_type
         when :first
           @payload = res[:value]
@@ -32,6 +38,10 @@ class Jerakia
         end
       end
       consolidate
+    end
+
+    def found?
+      @found
     end
 
     def consolidate

--- a/lib/jerakia/datasource/file.rb
+++ b/lib/jerakia/datasource/file.rb
@@ -88,7 +88,7 @@ class Jerakia::Datasource::File < Jerakia::Datasource::Instance
       path = paths.shift
       break unless path
       data = read_from_file(path)
-      unless data[request.key].nil?
+      if data.has_key?(request.key)
         response.submit data[request.key]
       end
     end

--- a/lib/jerakia/datasource/http.rb
+++ b/lib/jerakia/datasource/http.rb
@@ -53,7 +53,7 @@ class Jerakia::Datasource::Http < Jerakia::Datasource::Instance
       Jerakia.log.debug("Datasource provided #{data} (#{data.class}) looking for key #{request.key}")
 
       if data.is_a?(Hash)
-        if data.has_key(request.key)
+        if data.has_key?(request.key)
           Jerakia.log.debug("Found data #{data[request.key]}")
           response.submit data[request.key]
         end

--- a/lib/jerakia/datasource/http.rb
+++ b/lib/jerakia/datasource/http.rb
@@ -53,7 +53,7 @@ class Jerakia::Datasource::Http < Jerakia::Datasource::Instance
       Jerakia.log.debug("Datasource provided #{data} (#{data.class}) looking for key #{request.key}")
 
       if data.is_a?(Hash)
-        unless data[request.key].nil?
+        if data.has_key(request.key)
           Jerakia.log.debug("Found data #{data[request.key]}")
           response.submit data[request.key]
         end

--- a/lib/jerakia/policy.rb
+++ b/lib/jerakia/policy.rb
@@ -44,6 +44,7 @@ class Jerakia
         break unless lookup_instance.proceed?
       end
       answer.process_response(response_entries)
+      Jerakia.log.debug(answer)
       return answer
     end
 

--- a/lib/jerakia/server/rest.rb
+++ b/lib/jerakia/server/rest.rb
@@ -123,7 +123,8 @@ class Jerakia
         rescue Jerakia::Error => e
           request_failed(e.message, 501)
         end
-        encode_result({ :status => 'ok', 
+        encode_result({ :status => 'ok',
+                        :found => answer.found?,
                         :payload => answer.payload})
       end
 

--- a/test/fixtures/var/lib/jerakia/data/common/test.yaml
+++ b/test/fixtures/var/lib/jerakia/data/common/test.yaml
@@ -2,6 +2,8 @@
 
 root_password: "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
 
+null_value: ~
+
 booltrue: true
 boolfalse: false
 


### PR DESCRIPTION
Closes #102 

Currently there is no way to differentiate between a key explicitly set as NULL

Eg:

```yaml
foo: ~
```

Should return nul but we should know that this was explicitly set to null and not unresolved.

This will be used to determine the HTTP response code with a 404 being returned for not found and a 200 returned for found in the v2 API, for now, in v1 we just add this as a `found` field to the return data to keep backwards compatibility.

Backends should only call `response.submit` if they have found a value - failure to invoke the method will mean `found` is set to `false`.  The HTTP and File backends have been updated to reflect this.

