### PR TITLE
Bugfix: Datasource option defaults not being set.

### DIFF
--- a/lib/jerakia/datasource.rb
+++ b/lib/jerakia/datasource.rb
@@ -15,9 +15,8 @@ class Jerakia
       attr_reader :response
 
       def initialize(lookup, opts)
-        self.class.validate_options(opts)
         @response = Jerakia::Response.new(lookup)
-        @options = opts
+        @options = self.class.set_options(opts)
         @request = lookup.request 
         @features = []
       end
@@ -64,11 +63,17 @@ class Jerakia
           opt
         end
       end
-      def self.validate_options(args)
-        options.keys.each do |k|
-          options[k].call(args[k])
-        end
 
+      def self.set_options(args)
+        opts = {}
+        options.keys.each do |k|
+          opts[k] = options[k].call(args[k])
+        end
+        validate_options(args)
+        opts
+      end
+
+      def self.validate_options(args)
         args.keys.each do |k|
           raise Jerakia::DatasourceArgumentError, "Unknown option #{k}" unless options.keys.include?(k)
         end

--- a/lib/jerakia/datasource/file.rb
+++ b/lib/jerakia/datasource/file.rb
@@ -8,7 +8,7 @@ class Jerakia::Datasource::File < Jerakia::Datasource::Instance
 
   option :format,  :default => :yaml
   option :docroot, :default => '/var/lib/jerakia/data'
-  option :extention
+  option :extension
   option :enable_caching, :default => true
 
   def load_format_handler

--- a/test/fixtures/etc/jerakia/policy.d/default.rb
+++ b/test/fixtures/etc/jerakia/policy.d/default.rb
@@ -32,7 +32,6 @@ policy :default do
     datasource :file, {
       :docroot    => "test/fixtures/var/lib/jerakia/data",
       :enable_caching => true,
-      :format     => :yaml,
       :searchpath => [
         "host/#{scope[:hostname]}",
         "env/#{scope[:env]}",


### PR DESCRIPTION
Due to a bug in the option handling of the new datasource API in
2.0.0 defaults for datasource options were not being set.  This
can be tested by the removal of `:format => :yaml` in the test
policy as this should be set by the file datasource as a default.

This affects datasources that declare options like;

`option :foo, :default => :bar`

Also this commit fixes a typo with the `extension` option of the
file resource that was mistyped `extention` and therefore meant
this option would not work.