### PR TITLE
Added dig output handler

### DIFF
--- a/lib/jerakia/answer.rb
+++ b/lib/jerakia/answer.rb
@@ -29,12 +29,12 @@ class Jerakia
       responses.each do |res|
         case lookup_type
         when :first
-          @payload = res[:value]
-          @datatype = res[:datatype]
+          @payload = res.value
+          @datatype = res.datatype
           Jerakia.log.debug("Registered answer as #{payload}")
           break
         when :cascade
-          @payload << res[:value]
+          @payload << res.value
         end
       end
       consolidate

--- a/lib/jerakia/response.rb
+++ b/lib/jerakia/response.rb
@@ -1,6 +1,29 @@
 class Jerakia::Response < Jerakia
-  attr_accessor :entries
   attr_reader :lookup
+
+  class Entry
+    attr_reader :value
+    attr_reader :datatype
+    attr_reader :valid
+
+    def initialize(val)
+      @valid = true
+      set_value(val)
+    end
+
+    def invalidate
+      @valid = false
+    end
+
+    def valid?
+      @valid
+    end
+
+    def set_value(val)
+      @value = val
+      @datatype = val.class.to_s.downcase
+    end
+  end
 
   def initialize(lookup)
     @entries = []
@@ -17,28 +40,30 @@ class Jerakia::Response < Jerakia
     end
   end
 
+
   def submit(val)
     Jerakia.log.debug "Backend submitted #{val}"
     if want?
-      @entries << {
-        :value => val,
-        :datatype => val.class.to_s.downcase
-      }
+      @entries << Jerakia::Response::Entry.new(val)
       Jerakia.log.debug "Added answer #{val}"
     else
       no_more_answers
     end
   end
 
-  def values
-    Jerakia::Util.walk(@entries) do |entry|
+  def responses
+    @entries.each do |entry|
       yield entry
     end
   end
 
+  def entries
+    @entries.select { |e| e.valid? }
+  end
+
   def parse_values
     @entries.map! do |entry|
-      Jerakia::Util.walk(entry[:value]) do |v|
+      Jerakia::Util.walk(entry.value) do |v|
         yield v
       end
       entry

--- a/lib/jerakia/response/entry.rb
+++ b/lib/jerakia/response/entry.rb
@@ -1,0 +1,17 @@
+#class Jerakia::Response
+#    class Entry
+#
+#      attr_reader :value
+#      attr_reader :datatype
+#
+#      def initialize(val)
+#        set_value(val)
+#      end
+#
+#      def set_value(val)
+#        @value = val
+#        @datatype = val.class.to_s.downcase
+#      end
+#    end
+#end
+#

--- a/lib/jerakia/response/filter.rb
+++ b/lib/jerakia/response/filter.rb
@@ -1,10 +1,14 @@
 class Jerakia::Response
   module Filter
     def filter!(name, opts = {})
+
+      unless opts.is_a?(Hash) || opts.is_a?(Array)
+        raise Jerakia::PolicyError, "Output filters may only accept hashes or arrays as arguments"
+      end
       Jerakia::Util.autoload('response/filter', name)
       Jerakia.log.debug("Invoking output filter #{name}")
       instance_eval "extend Jerakia::Response::Filter::#{name.to_s.capitalize}"
-      instance_eval "self.filter_#{name} (#{opts})"
+      instance_eval "self.filter_#{name}(#{opts})"
     end
   end
 end

--- a/lib/jerakia/response/filter/dig.rb
+++ b/lib/jerakia/response/filter/dig.rb
@@ -1,0 +1,25 @@
+class Jerakia::Response
+  module Filter
+    module Dig
+      def filter_dig(path = [])
+        raise Jerakia::PolicyError, "Argument to output filter dig must be an array" unless path.is_a?(Array)
+        Jerakia.log.debug("[output_filter:dig]: Attempting to dig using path #{path}")
+        responses do |entry|
+
+          unless entry.value.is_a?(Hash)
+            raise Jerakia::Error, "Cannot perform dig on a non hash value"
+          end
+
+          value = Jerakia::Util.dig(entry.value, path.flatten)
+          if value == :not_found
+            Jerakia.log.debug('[output_filter:dig]: Digging value from response failed, invalidating')
+            entry.invalidate
+          else
+            entry.set_value(value)
+            Jerakia.log.debug("[output_filter:dig]: Re-submitting response as #{value}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jerakia/util.rb
+++ b/lib/jerakia/util.rb
@@ -6,6 +6,20 @@ class Jerakia
         require "jerakia/#{path}/#{mod}"
       end
 
+      def dig(data, dig_path)
+        key = dig_path.shift
+        if dig_path.empty?
+          if data.has_key?(key)
+            return data[key]
+          else
+            return :not_found
+          end
+        else
+          return :not_found unless data[key].is_a?(Hash)
+          return dig(data[key], dig_path)
+        end
+      end
+
       def walk(data)
         if data.is_a?(Hash)
           walk_hash(data) do |target|

--- a/spec/features/filter_dig_spec.rb
+++ b/spec/features/filter_dig_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Jerakia do
+  let(:subject) { Jerakia.new(:config =>  "#{JERAKIA_ROOT}/test/fixtures/etc/jerakia/jerakia.yaml") }
+  let(:request) { Jerakia::Request.new }
+  let(:answer) { subject.lookup(request) }
+
+  describe 'Digging values' do
+    context 'when looking up using the dig parameter' do
+      let(:request) do
+        Jerakia::Request.new(
+          key: 'tango',
+          policy: 'dig'
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should return the answer' do
+        expect(answer.payload).to eq('bar')
+      end
+
+      it 'should have a found state' do
+        expect(answer.found?).to eq(true)
+      end
+
+    end
+    context 'when a dug key is not found' do
+      let(:request) do
+        Jerakia::Request.new(
+          key: 'bad_key',
+          policy: 'dig'
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should return nil' do
+        expect(answer.payload).to eq(nil)
+      end
+
+      it 'should be set to not found' do
+        expect(answer.found?).to eq(false)
+      end
+
+    end
+
+  end
+end

--- a/spec/features/filter_strsub_spec.rb
+++ b/spec/features/filter_strsub_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Jerakia do
+  let(:subject) { Jerakia.new(:config =>  "#{JERAKIA_ROOT}/test/fixtures/etc/jerakia/jerakia.yaml") }
+  let(:request) { Jerakia::Request.new }
+  let(:answer) { subject.lookup(request) }
+
+  describe 'Substr values' do
+    context 'when looking up using the strsub outputfilter' do
+      let(:request) do
+        Jerakia::Request.new(
+          key: 'sub_value',
+          namespace: [ 'test' ],
+          metadata: { "env": "prod" }
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should return the answer' do
+        expect(answer.payload).to eq('Environment is prod')
+      end
+
+      it 'should have a found state' do
+        expect(answer.found?).to eq(true)
+      end
+
+    end
+  end
+end

--- a/test/fixtures/etc/jerakia/lib/jerakia/encryption/dummy.rb
+++ b/test/fixtures/etc/jerakia/lib/jerakia/encryption/dummy.rb
@@ -1,0 +1,15 @@
+class Jerakia
+  class Encryption
+    module Dummy
+      def signiture
+        /^vault:v[0-9]:[^ ]+$/
+      end
+
+      def decrypt(str)
+        'wibble'
+      end
+    end
+  end
+end
+
+ 

--- a/test/fixtures/etc/jerakia/policy.d/default.rb
+++ b/test/fixtures/etc/jerakia/policy.d/default.rb
@@ -40,6 +40,7 @@ policy :default do
     }
     exclude request.key, "skippy"
     output_filter :encryption
+    output_filter :strsub
   end
 end
 

--- a/test/fixtures/etc/jerakia/policy.d/dig.rb
+++ b/test/fixtures/etc/jerakia/policy.d/dig.rb
@@ -1,0 +1,31 @@
+policy :dig do
+
+  lookup :main do
+    datasource :dummy, {
+      :return => {
+        'document' =>  {
+          'settings' => {
+            'foo' => 'bar'
+          }
+        }
+      }
+    }
+
+    output_filter :dig, [ 'document', 'settings', request.key ]
+  end
+
+  lookup :main do
+    datasource :dummy, {
+      :return => {
+        'document' =>  {
+          'settings' => {
+            'tango' => 'bar'
+          }
+        }
+      }
+    }
+
+    output_filter :dig, [ 'document', 'settings', request.key ]
+  end
+end
+

--- a/test/fixtures/var/lib/jerakia/data/common/test.yaml
+++ b/test/fixtures/var/lib/jerakia/data/common/test.yaml
@@ -1,7 +1,10 @@
 ---
 
 root_password: "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+passwords:
+  root: "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
 
+sub_value: "Environment is %{env}"
 null_value: ~
 
 booltrue: true


### PR DESCRIPTION
Closes #111 

This adds an output handler called dig that lets you drill into
returned hash results and pull out a key

Eg: if a datasource returns;

```
{
  "document" => {
    "settings" => {
      "foo" => "bar"
    }
  }
}
```

if we are only interested in the key foo (assuming the lookup key
is foo) then we can dig this in the lookup with

  `output_filter :dig, [ 'document', 'settings', request.key ]`