### PR TITLE
(#11): Remove mandatory parameter checking for namespace in /lookup 

### DIFF
--- a/lib/jerakia/server/rest.rb
+++ b/lib/jerakia/server/rest.rb
@@ -98,7 +98,6 @@ class Jerakia
       end
 
       get '/v1/lookup/:key' do
-        mandatory_params(['namespace'], params)
         request_opts = {
           :key => params['key'],
           :namespace => params['namespace'].split(/\//),


### PR DESCRIPTION
As discussed in #11 - namespace has been made optional in other areas (CLI...etc) so the API should not enforce this parameter.

This removes the mandatory parameter check for the namespace parameter in API calls to /lookup/